### PR TITLE
Add conditional collectstatic management command

### DIFF
--- a/onlydjango/management/commands/collectstatic_if_needed.py
+++ b/onlydjango/management/commands/collectstatic_if_needed.py
@@ -1,0 +1,62 @@
+import os
+import subprocess
+
+from django.core.management import BaseCommand, call_command
+
+
+class Command(BaseCommand):
+    help = (
+        "Run collectstatic only if the last git commit touched static files. "
+        "Use -force to run regardless."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-force",
+            "--force",
+            action="store_true",
+            help="Run collectstatic regardless of git changes",
+        )
+
+    def handle(self, *args, **options):
+        if options["force"] or self._has_static_changes():
+            self.stdout.write("Collecting static files...")
+            call_command("collectstatic", "--noinput")
+        else:
+            self.stdout.write("No static changes detected. Skipping collectstatic.")
+
+    def _get_changed_files(self):
+        result = subprocess.run(
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+            capture_output=True,
+            text=True,
+        )
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def _has_static_changes(self):
+        static_exts = {
+            ".css",
+            ".js",
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".svg",
+            ".ico",
+            ".json",
+            ".woff",
+            ".woff2",
+            ".ttf",
+            ".eot",
+            ".otf",
+            ".scss",
+            ".sass",
+            ".less",
+        }
+        for path in self._get_changed_files():
+            lower = path.lower()
+            if "/static/" in lower or lower.startswith("static/"):
+                return True
+            if os.path.splitext(lower)[1] in static_exts:
+                return True
+        return False

--- a/onlydjango/tests/test_collectstatic_if_needed.py
+++ b/onlydjango/tests/test_collectstatic_if_needed.py
@@ -1,0 +1,40 @@
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import SimpleTestCase
+
+
+class CollectStaticIfNeededTests(SimpleTestCase):
+    def test_runs_when_static_changed(self):
+        with patch(
+            "onlydjango.management.commands.collectstatic_if_needed.call_command"
+        ) as mock_call:
+            with patch(
+                "onlydjango.management.commands.collectstatic_if_needed.Command._get_changed_files",
+                return_value=["onlydjango/static/js/app.js"],
+            ):
+                call_command("collectstatic_if_needed", stdout=StringIO())
+                mock_call.assert_called_once_with("collectstatic", "--noinput")
+
+    def test_skips_when_no_static_changes(self):
+        with patch(
+            "onlydjango.management.commands.collectstatic_if_needed.call_command"
+        ) as mock_call:
+            with patch(
+                "onlydjango.management.commands.collectstatic_if_needed.Command._get_changed_files",
+                return_value=["README.md"],
+            ):
+                call_command("collectstatic_if_needed", stdout=StringIO())
+                mock_call.assert_not_called()
+
+    def test_force_flag_runs(self):
+        with patch(
+            "onlydjango.management.commands.collectstatic_if_needed.call_command"
+        ) as mock_call:
+            with patch(
+                "onlydjango.management.commands.collectstatic_if_needed.Command._get_changed_files",
+                return_value=["README.md"],
+            ):
+                call_command("collectstatic_if_needed", "--force", stdout=StringIO())
+                mock_call.assert_called_once_with("collectstatic", "--noinput")


### PR DESCRIPTION
## Summary
- add `collectstatic_if_needed` management command to run collectstatic when static files changed or when forced
- cover conditional collectstatic behavior with tests

## Testing
- `uv sync`
- `DJANGO_SECRET_KEY=dummy DJANGO_SETTINGS_MODULE=onlydjango.settings.base uv run python manage.py test` *(fails: You're using the staticfiles app without having set the required STATIC_URL setting)*
- `uv run ruff check onlydjango/management/commands/collectstatic_if_needed.py onlydjango/tests/test_collectstatic_if_needed.py`

------
https://chatgpt.com/codex/tasks/task_e_6895d569f8048325bd60ad2e7c291d95